### PR TITLE
Move set_bind to before_serving hook and add close

### DIFF
--- a/src/gino_quart.py
+++ b/src/gino_quart.py
@@ -97,8 +97,8 @@ class Gino(_Gino):
                     del request.connection
                 return response
 
-        @app.before_first_request
-        async def before_first_request():
+        @app.before_serving
+        async def before_serving():
             dsn = app.config.get("DB_DSN")
             if not dsn:
                 dsn = URL(
@@ -119,6 +119,10 @@ class Gino(_Gino):
                 loop=asyncio.get_event_loop(),
                 **app.config.setdefault("DB_KWARGS", dict()),
             )
+
+        @app.after_serving
+        async def after_serving():
+            await self.pop_bind().close()
 
     async def first_or_404(self, *args, **kwargs):
         rv = await self.first(*args, **kwargs)


### PR DESCRIPTION
First off, thanks for writing and maintaining Gino --  nicely done and very useful!

Engine `set_bind` was in a `before_first_request hook`, and the engine was never closed.  Moved the `set_bind` to a `before_serving` hook, and added a `pop_bind`/`close` to an `after_serving` hook.

This makes it easier to properly initialize engine in custom `cli` commands, which typically only have access to an app context, and not to a request context.

Furthermore, another person reported that this resolves concurrency problems with hypercorn.

Finally, the proposed change also mirrors what lifecycle hooks other DB extensions use (e.g., Flask-SQLAlchemy, or Gino-Sanic).